### PR TITLE
Solved holding keypress glitch

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,6 +185,7 @@ function onloadHandler()
        ctx = canvas.getContext("2d"),
        width = canvas.width,
        height = canvas.height;
+    var keyPress = false;
 
    document.getElementById('felt_color').onchange = getFeltColor;
 
@@ -625,12 +626,19 @@ function onloadHandler()
    };
 
    document.addEventListener("keydown", keyDownEvent, false);
+   document.addEventListener("keyup", keyUpEvent, false);
 
    function keyDownEvent(e) {
        var keyCode = e.keyCode;
-       if(keyCode == 32) { //space bar
+       if(keyCode == 32 && !keyPress) { //space bar
+
+       		keyPress = true
            shoot();
        }
+   }
+
+   function keyUpEvent(e){
+   	keyPress = false; 
    }
 }
 


### PR DESCRIPTION
If user holds onto the space bar, the cue ball will be always moving. Change to disable the holding of the keypress